### PR TITLE
Add property DCF financials model

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1293,6 +1293,167 @@ function AssignUsersTab({ allUsers, assignLoading, toggleAssign, onViewContact }
 }
 
 function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
+  const DCF_ROW_DEFS = [
+    { key: 'grossRevenue', label: 'Gross Revenue', type: 'currency', category: 'income' },
+    { key: 'vacancyCreditLoss', label: 'Vacancy / Credit Loss', type: 'currency', category: 'income' },
+    { key: 'otherIncomeDcf', label: 'Other Income', type: 'currency', category: 'income' },
+    { key: 'effectiveGrossIncome', label: 'Effective Gross Income', type: 'currency', category: 'formula', readOnly: true },
+    { key: 'operatingExpensesDcf', label: 'Operating Expenses', type: 'currency', category: 'expense' },
+    { key: 'managementFeesDcf', label: 'Management Fees', type: 'currency', category: 'expense' },
+    { key: 'propertyTaxesDcf', label: 'Property Taxes', type: 'currency', category: 'expense' },
+    { key: 'insuranceDcf', label: 'Insurance', type: 'currency', category: 'expense' },
+    { key: 'reservesCapexDcf', label: 'Reserves / Capex', type: 'currency', category: 'expense' },
+    { key: 'tenantImprovements', label: 'Tenant Improvements (TI)', type: 'currency', category: 'expense' },
+    { key: 'leasingCommissions', label: 'Leasing Commissions (LC)', type: 'currency', category: 'expense' },
+    { key: 'capitalExpenditures', label: 'Additional Capex', type: 'currency', category: 'expense' },
+    { key: 'netOperatingIncomeDcf', label: 'Net Operating Income', type: 'currency', category: 'formula', readOnly: true },
+    { key: 'debtServiceDcf', label: 'Debt Service', type: 'currency', category: 'debt' },
+    { key: 'refinanceProceeds', label: 'Refinance Proceeds', type: 'currency', category: 'capital' },
+    { key: 'taxesDcf', label: 'Taxes', type: 'currency', category: 'tax' },
+    { key: 'cashFlowBeforeSale', label: 'Cash Flow Before Sale', type: 'currency', category: 'formula', readOnly: true },
+    { key: 'saleProceedsDcf', label: 'Sale Proceeds', type: 'currency', category: 'exit' },
+    { key: 'cashFlowAfterSale', label: 'Cash Flow After Sale', type: 'currency', category: 'formula', readOnly: true },
+    { key: 'waterfallSponsor', label: 'Sponsor Waterfall', type: 'currency', category: 'waterfall' },
+    { key: 'waterfallInvestor', label: 'Investor Waterfall', type: 'currency', category: 'waterfall' },
+  ]
+  const DCF_MAX_YEARS = 10
+  const defaultDcfModel = () => ({
+    years: Array.from({ length: DCF_MAX_YEARS }, (_, index) => {
+      const year = index + 1
+      return {
+        year,
+        grossRevenue: '',
+        vacancyCreditLoss: '',
+        otherIncomeDcf: '',
+        operatingExpensesDcf: '',
+        managementFeesDcf: '',
+        propertyTaxesDcf: '',
+        insuranceDcf: '',
+        reservesCapexDcf: '',
+        tenantImprovements: '',
+        leasingCommissions: '',
+        capitalExpenditures: '',
+        debtServiceDcf: '',
+        refinanceProceeds: '',
+        taxesDcf: '',
+        saleProceedsDcf: '',
+        waterfallSponsor: '',
+        waterfallInvestor: '',
+      }
+    })
+  })
+  function toTextNumber(value) {
+    return value === null || value === undefined ? '' : String(value)
+  }
+  function normalizeYearDraft(year = {}, yearNumber) {
+    return {
+      year: yearNumber,
+      grossRevenue: toTextNumber(year.grossRevenue),
+      vacancyCreditLoss: toTextNumber(year.vacancyCreditLoss),
+      otherIncomeDcf: toTextNumber(year.otherIncomeDcf),
+      operatingExpensesDcf: toTextNumber(year.operatingExpensesDcf),
+      managementFeesDcf: toTextNumber(year.managementFeesDcf),
+      propertyTaxesDcf: toTextNumber(year.propertyTaxesDcf),
+      insuranceDcf: toTextNumber(year.insuranceDcf),
+      reservesCapexDcf: toTextNumber(year.reservesCapexDcf),
+      tenantImprovements: toTextNumber(year.tenantImprovements),
+      leasingCommissions: toTextNumber(year.leasingCommissions),
+      capitalExpenditures: toTextNumber(year.capitalExpenditures),
+      debtServiceDcf: toTextNumber(year.debtServiceDcf),
+      refinanceProceeds: toTextNumber(year.refinanceProceeds),
+      taxesDcf: toTextNumber(year.taxesDcf),
+      saleProceedsDcf: toTextNumber(year.saleProceedsDcf),
+      waterfallSponsor: toTextNumber(year.waterfallSponsor),
+      waterfallInvestor: toTextNumber(year.waterfallInvestor),
+    }
+  }
+  function formatMoneyCell(value) {
+    if (value === null || value === undefined || value === '') return '—'
+    const num = Number(value)
+    if (!Number.isFinite(num)) return '—'
+    return '$' + num.toLocaleString(undefined, { maximumFractionDigits: 0 })
+  }
+  function parseNum(value) {
+    if (value === '' || value === null || value === undefined) return null
+    const num = Number(value)
+    return Number.isFinite(num) ? num : null
+  }
+  function buildDefaultDcfModelFromProperty(prop = {}) {
+    const model = defaultDcfModel()
+    const hold = Math.min(DCF_MAX_YEARS, Math.max(1, Number(prop.hold_period || 1)))
+    const rentGrowthPct = Number(prop.rent_growth || 0) / 100
+    const expenseGrowthPct = Number(prop.expense_growth || 0) / 100
+    const grossRentBase = Number(prop.gross_scheduled_rent || 0)
+    const vacancyPct = Number(prop.vacancy_rate || 0) / 100
+    const otherIncomeBase = Number(prop.other_income || 0)
+    const operatingExpensesBase = Number(prop.operating_expenses || 0)
+    const reservesBase = Number(prop.reserves_capex || 0)
+    const propertyTaxesBase = Number(prop.property_taxes || 0)
+    const insuranceBase = Number(prop.insurance || 0)
+    const managementFeePct = Number(prop.management_fee_pct || 0) / 100
+    const effectiveTaxRatePct = Number(prop.effective_tax_rate || 0) / 100
+    const debtServiceBase = (() => {
+      const loanAmt = Number(prop.loan_amount || 0)
+      const rate = Number(prop.interest_rate || 0) / 100 / 12
+      const amortYears = Number(prop.amortization_term || 0)
+      if (!loanAmt || !amortYears) return 0
+      const months = amortYears * 12
+      if (!months) return 0
+      if (rate === 0) return (loanAmt / months) * 12
+      return (loanAmt * rate / (1 - Math.pow(1 + rate, -months))) * 12
+    })()
+    const exitCapPct = Number(prop.exit_cap_rate || 0) / 100
+    const costOfSalePct = Number(prop.cost_of_sale || 0) / 100
+    const refiYearValue = Number(prop.refi_year || 0)
+    const refiLtvPct = Number(prop.refi_ltv || 0) / 100
+
+    for (let index = 0; index < DCF_MAX_YEARS; index += 1) {
+      const year = index + 1
+      const rentGrowthFactor = Math.pow(1 + rentGrowthPct, index)
+      const expenseGrowthFactor = Math.pow(1 + expenseGrowthPct, index)
+      const grossRevenue = grossRentBase * rentGrowthFactor
+      const vacancyLoss = grossRevenue * vacancyPct
+      const otherIncome = otherIncomeBase * rentGrowthFactor
+      const effectiveGrossIncome = grossRevenue - vacancyLoss + otherIncome
+      const operatingExpensesYear = operatingExpensesBase * expenseGrowthFactor
+      const managementFees = effectiveGrossIncome * managementFeePct
+      const propertyTaxesYear = propertyTaxesBase * expenseGrowthFactor
+      const insuranceYear = insuranceBase * expenseGrowthFactor
+      const reservesYear = reservesBase * expenseGrowthFactor
+      const noi = effectiveGrossIncome - operatingExpensesYear - managementFees - propertyTaxesYear - insuranceYear - reservesYear
+      const taxesYear = Math.max(0, noi) * effectiveTaxRatePct
+      const saleProceeds = year === hold && exitCapPct > 0 ? Math.max(0, noi) / exitCapPct * (1 - costOfSalePct) : 0
+      const refinanceProceeds = refiYearValue === year && refiLtvPct > 0 && exitCapPct > 0 ? (Math.max(0, noi) / exitCapPct) * refiLtvPct : 0
+      model.years[index] = normalizeYearDraft({
+        year,
+        grossRevenue: Math.round(grossRevenue),
+        vacancyCreditLoss: Math.round(vacancyLoss),
+        otherIncomeDcf: Math.round(otherIncome),
+        operatingExpensesDcf: Math.round(operatingExpensesYear),
+        managementFeesDcf: Math.round(managementFees),
+        propertyTaxesDcf: Math.round(propertyTaxesYear),
+        insuranceDcf: Math.round(insuranceYear),
+        reservesCapexDcf: Math.round(reservesYear),
+        debtServiceDcf: Math.round(debtServiceBase),
+        refinanceProceeds: Math.round(refinanceProceeds),
+        taxesDcf: Math.round(taxesYear),
+        saleProceedsDcf: Math.round(saleProceeds),
+      }, year)
+    }
+    return model
+  }
+  function hydrateDcfModel(rawModel, prop = {}) {
+    const base = rawModel && typeof rawModel === 'object' && !Array.isArray(rawModel) ? rawModel : {}
+    const incomingYears = Array.isArray(base.years) ? base.years : []
+    const fallback = buildDefaultDcfModelFromProperty(prop)
+    return {
+      years: Array.from({ length: DCF_MAX_YEARS }, (_, index) => {
+        const yearNumber = index + 1
+        const source = incomingYears[index] || fallback.years[index] || {}
+        return normalizeYearDraft(source, yearNumber)
+      })
+    }
+  }
   const [tab, setTab] = useState('details')
   const [pin, setPin] = useState('')
   const [address, setAddress] = useState('')
@@ -1363,6 +1524,7 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
   const [refiLtv, setRefiLtv] = useState('')
   const [refiRate, setRefiRate] = useState('')
   const [refiYear, setRefiYear] = useState('')
+  const [dcfModel, setDcfModel] = useState(defaultDcfModel())
   const [saving, setSaving] = useState(false)
   const [savedSignal, setSavedSignal] = useState(0)
   const [media, setMedia] = useState([])
@@ -1442,6 +1604,7 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
     setRefiLtv(p.refi_ltv ?? '')
     setRefiRate(p.refi_rate ?? '')
     setRefiYear(p.refi_year ?? '')
+    setDcfModel(hydrateDcfModel(p.dcf_model, p))
   }
 
   useEffect(() => {
@@ -1464,9 +1627,46 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
       setManagementFeePct(''); setInsurance(''); setPropertyTaxes('')
       setLandValuePct(''); setCostSegBonusPct(''); setEffectiveTaxRate(''); setDepreciationRecaptureRate('')
       setRefiLtv(''); setRefiRate(''); setRefiYear('')
+      setDcfModel(defaultDcfModel())
       setTab('details')
     }
   }, [property, open])
+
+  const activeHoldPeriod = Math.min(DCF_MAX_YEARS, Math.max(1, Number(holdPeriod || 1)))
+  const visibleDcfYears = dcfModel.years.slice(0, activeHoldPeriod)
+  function updateDcfCell(yearIndex, field, value) {
+    setDcfModel(prev => ({
+      years: prev.years.map((row, index) => index === yearIndex ? { ...row, [field]: value } : row)
+    }))
+  }
+  function getComputedDcfValue(yearRow, rowKey) {
+    const grossRevenueVal = parseNum(yearRow.grossRevenue) || 0
+    const vacancyLossVal = parseNum(yearRow.vacancyCreditLoss) || 0
+    const otherIncomeVal = parseNum(yearRow.otherIncomeDcf) || 0
+    const operatingExpensesVal = parseNum(yearRow.operatingExpensesDcf) || 0
+    const managementFeesVal = parseNum(yearRow.managementFeesDcf) || 0
+    const propertyTaxesVal = parseNum(yearRow.propertyTaxesDcf) || 0
+    const insuranceVal = parseNum(yearRow.insuranceDcf) || 0
+    const reservesVal = parseNum(yearRow.reservesCapexDcf) || 0
+    const tenantImprovementsVal = parseNum(yearRow.tenantImprovements) || 0
+    const leasingCommissionsVal = parseNum(yearRow.leasingCommissions) || 0
+    const capitalExpendituresVal = parseNum(yearRow.capitalExpenditures) || 0
+    const debtServiceVal = parseNum(yearRow.debtServiceDcf) || 0
+    const refinanceVal = parseNum(yearRow.refinanceProceeds) || 0
+    const taxesVal = parseNum(yearRow.taxesDcf) || 0
+    const saleProceedsVal = parseNum(yearRow.saleProceedsDcf) || 0
+    const sponsorVal = parseNum(yearRow.waterfallSponsor) || 0
+    const investorVal = parseNum(yearRow.waterfallInvestor) || 0
+    const effectiveGrossIncome = grossRevenueVal - vacancyLossVal + otherIncomeVal
+    const netOperatingIncome = effectiveGrossIncome - operatingExpensesVal - managementFeesVal - propertyTaxesVal - insuranceVal - reservesVal - tenantImprovementsVal - leasingCommissionsVal - capitalExpendituresVal
+    const cashFlowBeforeSale = netOperatingIncome - debtServiceVal + refinanceVal - taxesVal
+    const cashFlowAfterSale = cashFlowBeforeSale + saleProceedsVal - sponsorVal - investorVal
+    if (rowKey === 'effectiveGrossIncome') return effectiveGrossIncome
+    if (rowKey === 'netOperatingIncomeDcf') return netOperatingIncome
+    if (rowKey === 'cashFlowBeforeSale') return cashFlowBeforeSale
+    if (rowKey === 'cashFlowAfterSale') return cashFlowAfterSale
+    return null
+  }
 
   useEffect(() => {
     if (open && property?.id) {
@@ -1594,6 +1794,28 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
       refi_ltv: refiLtv !== '' ? Number(refiLtv) : null,
       refi_rate: refiRate !== '' ? Number(refiRate) : null,
       refi_year: refiYear !== '' ? Number(refiYear) : null,
+      dcf_model: {
+        years: dcfModel.years.map((year, index) => ({
+          year: index + 1,
+          grossRevenue: parseNum(year.grossRevenue),
+          vacancyCreditLoss: parseNum(year.vacancyCreditLoss),
+          otherIncomeDcf: parseNum(year.otherIncomeDcf),
+          operatingExpensesDcf: parseNum(year.operatingExpensesDcf),
+          managementFeesDcf: parseNum(year.managementFeesDcf),
+          propertyTaxesDcf: parseNum(year.propertyTaxesDcf),
+          insuranceDcf: parseNum(year.insuranceDcf),
+          reservesCapexDcf: parseNum(year.reservesCapexDcf),
+          tenantImprovements: parseNum(year.tenantImprovements),
+          leasingCommissions: parseNum(year.leasingCommissions),
+          capitalExpenditures: parseNum(year.capitalExpenditures),
+          debtServiceDcf: parseNum(year.debtServiceDcf),
+          refinanceProceeds: parseNum(year.refinanceProceeds),
+          taxesDcf: parseNum(year.taxesDcf),
+          saleProceedsDcf: parseNum(year.saleProceedsDcf),
+          waterfallSponsor: parseNum(year.waterfallSponsor),
+          waterfallInvestor: parseNum(year.waterfallInvestor),
+        }))
+      },
     })
     setSaving(false)
     setSavedSignal(s => s + 1)
@@ -1916,6 +2138,61 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
         {/* Financials tab */}
         {tab === 'financials' && (
           <div className="space-y-4">
+              <div className="rounded-2xl border border-base-300 overflow-hidden bg-base-100 shadow-sm">
+                <div className="px-4 py-3 border-b border-base-300 flex items-center justify-between gap-3 flex-wrap">
+                  <div>
+                    <div className="text-sm font-semibold uppercase tracking-[0.22em] text-base-content/50">Discounted Cash Flow</div>
+                    <p className="text-xs text-base-content/50 mt-1">Editable yearly institutional model saved per property. Black rows are formula outputs.</p>
+                  </div>
+                  <div className="badge badge-outline">{activeHoldPeriod} Year Hold</div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="table table-pin-rows table-pin-cols text-sm min-w-[1200px]">
+                    <thead>
+                      <tr className="bg-base-200/80">
+                        <th className="min-w-[260px] bg-base-200">Line Item</th>
+                        {visibleDcfYears.map((year) => (
+                          <th key={year.year} className="text-center bg-base-200 min-w-[140px]">Year {year.year}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {DCF_ROW_DEFS.map((row) => (
+                        <tr key={row.key} className={row.readOnly ? 'bg-base-200/40' : ''}>
+                          <th className="font-medium whitespace-nowrap">
+                            <div className="flex flex-col">
+                              <span>{row.label}</span>
+                              <span className="text-[10px] uppercase tracking-[0.18em] text-base-content/35">{row.category}</span>
+                            </div>
+                          </th>
+                          {visibleDcfYears.map((year, yearIndex) => {
+                            const computedValue = row.readOnly ? getComputedDcfValue(year, row.key) : null
+                            return (
+                              <td key={`${row.key}-${year.year}`} className="align-middle">
+                                {row.readOnly ? (
+                                  <div className="input input-bordered input-md w-full md:text-base cursor-default flex items-center justify-end" style={{ color: '#000', fontWeight: 700 }}>
+                                    {formatMoneyCell(computedValue)}
+                                  </div>
+                                ) : (
+                                  <NumericInput
+                                    placeholder="0"
+                                    value={year[row.key]}
+                                    onChange={(value) => updateDcfCell(yearIndex, row.key, value)}
+                                    className="input input-bordered input-md w-full md:text-base text-right"
+                                    style={{ color: '#1d4ed8' }}
+                                    disabled={!isAdmin}
+                                    allowDecimal={false}
+                                  />
+                                )}
+                              </td>
+                            )
+                          })}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
 
               {/* Core financials */}
               <div className="space-y-3">
@@ -2502,9 +2779,11 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
 
 
         {/* ── Right panel: map ── */}
-        <div className="hidden md:flex flex-1 border-l border-base-300" style={{ minHeight: '500px' }}>
-          <PropertyMap address={address} />
-        </div>
+        {tab !== 'financials' && (
+          <div className="hidden md:flex flex-1 border-l border-base-300" style={{ minHeight: '500px' }}>
+            <PropertyMap address={address} />
+          </div>
+        )}
 
       </div>
       <form method="dialog" className="modal-backdrop" onClick={onClose}><button>close</button></form>

--- a/server/index.js
+++ b/server/index.js
@@ -164,6 +164,7 @@ async function initializeSchema() {
   await pool.query(`ALTER TABLE properties ADD COLUMN IF NOT EXISTS refi_ltv NUMERIC`);
   await pool.query(`ALTER TABLE properties ADD COLUMN IF NOT EXISTS refi_rate NUMERIC`);
   await pool.query(`ALTER TABLE properties ADD COLUMN IF NOT EXISTS refi_year INTEGER`);
+  await pool.query(`ALTER TABLE properties ADD COLUMN IF NOT EXISTS dcf_model JSONB DEFAULT '{}'`);
 
   await pool.query(`CREATE TABLE IF NOT EXISTS property_assignments (
     id SERIAL PRIMARY KEY,
@@ -1114,7 +1115,7 @@ app.post('/api/properties', async (req, res) => {
     tenant_gross_sales, tenant_base_rent,
     management_fee_pct, insurance, property_taxes,
     land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-    refi_ltv, refi_rate, refi_year
+    refi_ltv, refi_rate, refi_year, dcf_model
   } = req.body || {};
   if (!pin || !pin.trim()) return res.status(400).json({ error: 'PIN required' });
   if (!address || !address.trim()) return res.status(400).json({ error: 'address required' });
@@ -1136,8 +1137,8 @@ app.post('/api/properties', async (req, res) => {
         tenant_gross_sales, tenant_base_rent,
         management_fee_pct, insurance, property_taxes,
         land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-        refi_ltv, refi_rate, refi_year)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53,$54,$55,$56,$57,$58,$59,$60,$61,$62) RETURNING id`,
+        refi_ltv, refi_rate, refi_year, dcf_model)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53,$54,$55,$56,$57,$58,$59,$60,$61,$62,$63) RETURNING id`,
       [pin.trim(), address.trim(), county.trim(), req.session.user.id,
        price || null, square_feet || null, lot_size || null, year_built || null,
        on_major_road || false, traffic_vpd || null, on_corner_lot || false,
@@ -1161,7 +1162,8 @@ app.post('/api/properties', async (req, res) => {
        management_fee_pct || null, insurance || null, property_taxes || null,
        land_value_pct || null, cost_seg_bonus_pct || null, effective_tax_rate || null,
        depreciation_recapture_rate || null,
-       refi_ltv || null, refi_rate || null, refi_year || null]
+       refi_ltv || null, refi_rate || null, refi_year || null,
+       JSON.stringify(dcf_model || {})]
     );
     await logAudit(req.session.user.id, req.session.user.email, 'create_property', { pin, address, county }, null, null, clientIp(req));
     res.json({ id: result.rows[0].id, pin, address, county });
@@ -1201,7 +1203,7 @@ app.get('/api/properties', async (req, res) => {
               tenant_gross_sales, tenant_base_rent,
               management_fee_pct, insurance, property_taxes,
               land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-              refi_ltv, refi_rate, refi_year,
+              refi_ltv, refi_rate, refi_year, dcf_model,
               created_by, created_at, updated_at
        FROM properties ${where} ORDER BY id DESC LIMIT $${listParams.length - 1} OFFSET $${listParams.length}`,
       listParams
@@ -1232,7 +1234,7 @@ app.get('/api/properties/:id', async (req, res) => {
               tenant_gross_sales, tenant_base_rent,
               management_fee_pct, insurance, property_taxes,
               land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-              refi_ltv, refi_rate, refi_year,
+              refi_ltv, refi_rate, refi_year, dcf_model,
               created_by, created_at, updated_at
        FROM properties WHERE id = $1`, [propId]);
     if (result.rows.length === 0) return res.status(404).json({ error: 'not found' });
@@ -1262,7 +1264,7 @@ app.put('/api/properties/:id', async (req, res) => {
     tenant_gross_sales, tenant_base_rent,
     management_fee_pct, insurance, property_taxes,
     land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-    refi_ltv, refi_rate, refi_year
+    refi_ltv, refi_rate, refi_year, dcf_model
   } = req.body || {};
   if (!pin || !pin.trim()) return res.status(400).json({ error: 'PIN required' });
   if (!address || !address.trim()) return res.status(400).json({ error: 'address required' });
@@ -1284,7 +1286,7 @@ app.put('/api/properties/:id', async (req, res) => {
               tenant_gross_sales, tenant_base_rent,
               management_fee_pct, insurance, property_taxes,
               land_value_pct, cost_seg_bonus_pct, effective_tax_rate, depreciation_recapture_rate,
-              refi_ltv, refi_rate, refi_year
+              refi_ltv, refi_rate, refi_year, dcf_model
        FROM properties WHERE id=$1`, [propId]
     );
     if (oldResult.rows.length === 0) return res.status(404).json({ error: 'not found' });
@@ -1325,12 +1327,14 @@ app.put('/api/properties/:id', async (req, res) => {
       land_value_pct: land_value_pct || null, cost_seg_bonus_pct: cost_seg_bonus_pct || null,
       effective_tax_rate: effective_tax_rate || null,
       depreciation_recapture_rate: depreciation_recapture_rate || null,
-      refi_ltv: refi_ltv || null, refi_rate: refi_rate || null, refi_year: refi_year || null
+      refi_ltv: refi_ltv || null, refi_rate: refi_rate || null, refi_year: refi_year || null,
+      dcf_model: JSON.stringify(dcf_model || {})
     };
 
     // Build field-level diff — normalize types for accurate comparison
     const changes = {};
     const arrayFields = new Set(['major_interstates', 'logistics_hubs', 'landmarks', 'water_sources', 'military_bases']);
+    const jsonFields = new Set(['dcf_model']);
     for (const key of Object.keys(newVals)) {
       let oldNorm, newNorm, oldDisplay, newDisplay;
       if (arrayFields.has(key)) {
@@ -1338,6 +1342,11 @@ app.put('/api/properties/:id', async (req, res) => {
         oldNorm = JSON.stringify(old[key] ?? []);
         newNorm = newVals[key]; // already JSON.stringify'd
         oldDisplay = old[key] ?? [];
+        newDisplay = JSON.parse(newNorm);
+      } else if (jsonFields.has(key)) {
+        oldNorm = JSON.stringify(old[key] ?? {});
+        newNorm = newVals[key];
+        oldDisplay = old[key] ?? {};
         newDisplay = JSON.parse(newNorm);
       } else {
         // Scalar: compare as strings, treat null/0/'' consistently
@@ -1376,9 +1385,9 @@ app.put('/api/properties/:id', async (req, res) => {
         management_fee_pct=$53, insurance=$54, property_taxes=$55,
         land_value_pct=$56, cost_seg_bonus_pct=$57, effective_tax_rate=$58,
         depreciation_recapture_rate=$59,
-        refi_ltv=$60, refi_rate=$61, refi_year=$62,
+        refi_ltv=$60, refi_rate=$61, refi_year=$62, dcf_model=$63,
         updated_at=CURRENT_TIMESTAMP
-       WHERE id=$63`,
+       WHERE id=$64`,
       [newVals.pin, newVals.address, newVals.county,
        newVals.price, newVals.square_feet, newVals.lot_size, newVals.year_built,
        newVals.on_major_road, newVals.traffic_vpd, newVals.on_corner_lot,
@@ -1403,7 +1412,7 @@ app.put('/api/properties/:id', async (req, res) => {
        newVals.management_fee_pct, newVals.insurance, newVals.property_taxes,
        newVals.land_value_pct, newVals.cost_seg_bonus_pct, newVals.effective_tax_rate,
        newVals.depreciation_recapture_rate,
-       newVals.refi_ltv, newVals.refi_rate, newVals.refi_year,
+       newVals.refi_ltv, newVals.refi_rate, newVals.refi_year, newVals.dcf_model,
        propId]
     );
     if (result.rowCount === 0) return res.status(404).json({ error: 'not found' });


### PR DESCRIPTION
Adds a saved per-property discounted cash flow model to the Financials tab, hides the map only while Financials is active, and persists the yearly DCF table as JSON in the property record.