### PR TITLE
Offset property modal below navbar

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1806,9 +1806,9 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave }) {
   const tabLabel = { details: 'Details', financials: 'Financials', media: 'Media', documents: 'Documents', assign: 'Assign Users' }
 
   return (
-    <div className="modal modal-open" style={{zIndex: 30}}>
+    <div className="modal modal-open" style={{ zIndex: 30, paddingTop: '64px' }}>
       {/* Wide container: left form + right map */}
-      <div className="modal-box p-0 w-screen h-screen max-w-none max-h-none rounded-none flex flex-col overflow-hidden">
+      <div className="modal-box p-0 w-screen h-[calc(100vh-64px)] max-w-none max-h-none rounded-none flex flex-col overflow-hidden">
         <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-base-300 md:hidden">
           <h3 className="font-bold text-xl">
             {property?.id ? property.address : 'New Property'}


### PR DESCRIPTION
Offsets the property modal below the sticky app navbar so the top of the property detail view is no longer hidden behind the menu.