### PR TITLE
Import useMemo for financials recalculation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, Component } from 'react'
+import { useEffect, useMemo, useRef, useState, Component } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'
 


### PR DESCRIPTION
Fixes the runtime error caused by using useMemo without importing it from React.