### PR TITLE
Fix TDZ: convert summarizeScenarioModel to useCallback

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2402,7 +2402,7 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave, topOffs
   const dscrFromEngine = adjustedNoiValue !== null && annualDebtServiceAmount > 0
     ? (adjustedNoiValue / annualDebtServiceAmount)
     : null
-  function summarizeScenarioModel(scenarioKey, propertyOverrides = {}) {
+  const summarizeScenarioModel = useCallback((scenarioKey, propertyOverrides = {}) => {
     const scenarioProp = buildScenarioProperty(scenarioKey, {}, propertyOverrides)
     const scenarioModel = normalizeDcfModel(scenarioProp.dcf_model, scenarioProp)
     const scenarioHold = Math.min(DCF_MAX_YEARS, Math.max(1, Number(scenarioProp.hold_period || 1)))
@@ -2442,7 +2442,7 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave, topOffs
       covenantBreach,
       cashTrap: firstYear ? firstYear.cashFlowAfterSale < 0 : false,
     }
-  }
+  }, [dcfModel, buildScenarioProperty, normalizeDcfModel, getComputedDcfValue, parseNum, calculateIrr])
   const scenarioComparison = useMemo(
     () => ['base', 'upside', 'downside'].map((scenarioKey) => summarizeScenarioModel(scenarioKey)),
     [summarizeScenarioModel]


### PR DESCRIPTION
Vite/Rolldown minifies inner function declarations to const expressions. When useMemo deps reference the minified name before its initializer runs in the bundle, it causes a 'can't access lexical declaration before initialization' TDZ crash in production.

Fix: convert summarizeScenarioModel from a function declaration to a useCallback so it is guaranteed to be initialized before the useMemo calls that depend on it.