### PR TITLE
Disable Rolldown identifier minification to fix production TDZ crash

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,5 +8,12 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:3000'
     }
+  },
+  build: {
+    // Rolldown's identifier minification renames function declarations in a way
+    // that creates temporal dead zone crashes in production (can't access
+    // lexical declaration before initialization). Disabling minification
+    // prevents the renaming; Rolldown still strips dead code via "dce-only".
+    minify: false,
   }
 })


### PR DESCRIPTION
Rolldown's identifier minifier renames function declarations to short names that create temporal dead zone errors ('can't access lexical declaration before initialization') in the production bundle. Setting minify:false switches to dce-only mode. Gzip size goes from ~151KB to ~215KB — acceptable trade-off for a stable app.