### PR TITLE
Fix source-level TDZ: priorControllableMonthly declared before dependency

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1525,7 +1525,6 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave, topOffs
       : 0
     let suspendedLossCarryforward = startingSuspendedLossCarryforward
     let accumulatedDepreciation = 0
-    let priorControllableMonthly = monthlyOperatingExpenseBase * controllableExpensePct
     const timingMode = source.timing?.granularity || 'monthly'
     const saleMonthValue = clampMonth(source.timing?.saleMonth || 12, 12)
     const totalMonths = hold * 12
@@ -1563,6 +1562,7 @@ function PropertyDetailModal({ open, property, isAdmin, onClose, onSave, topOffs
     const monthlyRows = []
 
     const monthlyOperatingExpenseBase = operatingExpensesBase / 12
+    let priorControllableMonthly = monthlyOperatingExpenseBase * controllableExpensePct
     const monthlyOtherIncomeBase = otherIncomeBase / 12
     const monthlyPropertyTaxesBase = propertyTaxesBase / 12
     const monthlyInsuranceBase = insuranceBase / 12


### PR DESCRIPTION
monthlyOperatingExpenseBase was declared at line 1565 but priorControllableMonthly used it at line 1528. Genuine const TDZ in source. Fixed by moving initialization to immediately after its dependency.