### PR TITLE
Add missing useCallback to React import

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, Component } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, Component } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'
 


### PR DESCRIPTION
useCallback was used in App.jsx but not imported from react.