### PR TITLE
Restore live financial calculations

### DIFF
--- a/client/src/PropertyDetailModal.jsx
+++ b/client/src/PropertyDetailModal.jsx
@@ -1313,7 +1313,7 @@ export default function PropertyDetailModal({ open, property, isAdmin, onClose, 
     }))
   }
   const liveDerivedDcfModel = useMemo(
-    () => normalizeDcfModel(buildPropertyFromDraft().dcf_model, buildPropertyFromDraft()),
+    () => buildDefaultDcfModelFromProperty(buildPropertyFromDraft()),
     [
       property,
       price,


### PR DESCRIPTION
## Summary
- fix the Financials tab live-engine path so computed outputs use the recalculated DCF model instead of rehydrated draft years
- restore auto-updating NOI, EGI, debt service, cap rate, DSCR, and related derived metrics when inputs change
- keep the existing save payload and normalized edit model behavior unchanged
