### PR TITLE
Fix: PhotoCropper cancel no longer triggers form validation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -155,7 +155,7 @@ function AddUserForm({ onCreated }) {
   const displayName = [firstName, lastName].filter(Boolean).join(' ') || email || 'New User'
 
   return (
-    <form onSubmit={createUser} className="space-y-5">
+    <form onSubmit={createUser} className="space-y-5" noValidate>
       {showCropper && cropSrc && (
         <PhotoCropper
           src={cropSrc}


### PR DESCRIPTION
- Remove HTML5 form validation
- Use manual validation in createUser handler
- Canceling photo crop modal no longer shows validation errors
- Build: ✅ Success