### PR TITLE
Integrate Hunter.io email verification into Lookup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -904,6 +904,50 @@ function PropertiesPage({ user }) {
 }
 
 function LookupPage() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [notConfigured, setNotConfigured] = useState(false)
+  const [result, setResult] = useState(null)
+
+  async function verifyEmail(e) {
+    e.preventDefault()
+    setError('')
+    setNotConfigured(false)
+    setResult(null)
+    if (!email.trim()) {
+      setError('Email is required')
+      return
+    }
+    setLoading(true)
+    try {
+      const data = await apiFetch('/api/lookup/email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      })
+      setResult(data)
+    } catch (e) {
+      if (e.status === 503) {
+        setNotConfigured(true)
+        return
+      }
+      setError(e.message || 'Verification failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const flags = result?.result ? [
+    { label: 'Disposable', value: result.result.disposable },
+    { label: 'Webmail', value: result.result.webmail },
+    { label: 'Gibberish', value: result.result.gibberish },
+    { label: 'SMTP check', value: result.result.smtp_check },
+    { label: 'Accept-all', value: result.result.accept_all },
+    { label: 'Block', value: result.result.block },
+    { label: 'MX present', value: result.result.mx_records }
+  ] : []
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -916,13 +960,76 @@ function LookupPage() {
       <div className="card bg-base-100 border border-base-300 shadow-sm">
         <div className="card-body p-5 md:p-6 space-y-5">
           <div className="space-y-1">
-            <h3 className="text-lg font-semibold">Lookup tools coming soon</h3>
+            <h3 className="text-lg font-semibold">Email Verification</h3>
             <p className="text-sm text-base-content/55">
-              This admin-only area is reserved for future lookup utilities.
+              Verify an email address with Hunter.io without exposing the API key to the browser.
             </p>
           </div>
+          <form onSubmit={verifyEmail} className="space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row">
+              <input
+                type="email"
+                placeholder="name@example.com"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="input input-bordered flex-1"
+              />
+              <button className="btn btn-primary md:min-w-32" type="submit" disabled={loading}>
+                {loading ? 'Verifying…' : 'Verify'}
+              </button>
+            </div>
+          </form>
+
+          {error && (
+            <div className="rounded-xl border border-base-300 bg-base-200/40 px-4 py-3 text-sm text-error">
+              {error}
+            </div>
+          )}
+
+          {notConfigured && (
+            <div className="rounded-xl border border-dashed border-base-300 bg-base-200/40 px-4 py-4 text-sm text-base-content/60">
+              Hunter.io is not configured on this server yet.
+            </div>
+          )}
+
+          {result?.result && (
+            <div className="rounded-xl border border-base-300 bg-base-200/30 p-4 md:p-5 space-y-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-widest text-base-content/50">Overall verdict</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                    <span className="badge badge-neutral">{result.result.result || 'unknown'}</span>
+                    {result.result.status && <span className="badge badge-outline">{result.result.status}</span>}
+                  </div>
+                </div>
+                {result.result.score !== null && result.result.score !== undefined && (
+                  <div className="text-sm text-base-content/70">
+                    Score <span className="font-semibold text-base-content">{result.result.score}</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {flags.map(flag => (
+                  <div key={flag.label} className="flex items-center justify-between rounded-lg border border-base-300 px-3 py-2 text-sm">
+                    <span className="text-base-content/70">{flag.label}</span>
+                    <span className={`badge badge-sm ${flag.value ? 'badge-neutral' : 'badge-outline'}`}>
+                      {flag.value ? 'Yes' : 'No'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {result.result.sources !== null && result.result.sources !== undefined && (
+                <div className="text-sm text-base-content/70">
+                  Source count <span className="font-medium text-base-content">{result.result.sources}</span>
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="rounded-xl border border-dashed border-base-300 bg-base-200/40 px-4 py-6 text-sm text-base-content/60">
-            No external verifier is currently configured. Lookup integrations will be added here in a future update.
+            More lookup tools for phone, name, address, and business research can be added here over time.
           </div>
         </div>
       </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,4 @@
 SESSION_SECRET=change-me-to-a-secure-random-string
 DB_PATH=./users.db
 PORT=3000
+HUNTER_API_KEY= # Hunter.io email verification API key

--- a/server/index.js
+++ b/server/index.js
@@ -364,6 +364,46 @@ async function postJson(url, payload) {
     if (text) {
       try { data = JSON.parse(text); } catch { data = { message: text }; }
     }
+
+    async function getJson(url) {
+      if (typeof fetch === 'function') {
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: { 'Accept': 'application/json' }
+        });
+        const text = await response.text();
+        let data = null;
+        if (text) {
+          try { data = JSON.parse(text); } catch { data = { message: text }; }
+        }
+        return { ok: response.ok, status: response.status, data };
+      }
+
+      return new Promise((resolve, reject) => {
+        const target = new URL(url);
+        const request = https.request({
+          protocol: target.protocol,
+          hostname: target.hostname,
+          port: target.port || (target.protocol === 'https:' ? 443 : 80),
+          path: `${target.pathname}${target.search}`,
+          method: 'GET',
+          headers: { 'Accept': 'application/json' }
+        }, response => {
+          let raw = '';
+          response.setEncoding('utf8');
+          response.on('data', chunk => { raw += chunk; });
+          response.on('end', () => {
+            let data = null;
+            if (raw) {
+              try { data = JSON.parse(raw); } catch { data = { message: raw }; }
+            }
+            resolve({ ok: response.statusCode >= 200 && response.statusCode < 300, status: response.statusCode || 502, data });
+          });
+        });
+        request.on('error', reject);
+        request.end();
+      });
+    }
     return { ok: response.ok, status: response.status, data };
   }
 
@@ -525,6 +565,59 @@ app.post('/api/lookup-user', async (req, res) => {
     const { first_name, last_name, profile_photo, login_count } = result.rows[0];
     res.json({ found: true, first_name, last_name, profile_photo, login_count: login_count || 0 });
   } catch { res.json({ found: false }); }
+});
+
+app.post('/api/lookup/email', async (req, res) => {
+  if (!req.session.user || req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  const email = sanitizeEmail(req.body?.email);
+  if (!email) return res.status(400).json({ error: 'email required' });
+  if (!isValidEmail(email)) return res.status(400).json({ error: 'valid email required' });
+
+  const hunterApiKey = process.env.HUNTER_API_KEY;
+  if (!hunterApiKey) {
+    return res.status(503).json({ error: 'lookup service not configured', code: 'LOOKUP_NOT_CONFIGURED' });
+  }
+
+  try {
+    const url = `https://api.hunter.io/v2/email-verifier?email=${encodeURIComponent(email)}&api_key=${encodeURIComponent(hunterApiKey)}`;
+    const upstream = await getJson(url);
+    if (!upstream.ok) {
+      const message = upstream.data?.errors?.[0]?.details
+        || upstream.data?.errors?.[0]?.message
+        || upstream.data?.message
+        || 'lookup failed';
+      return res.status(502).json({ error: message });
+    }
+
+    const verifier = upstream.data?.data;
+    if (!verifier) return res.status(502).json({ error: 'lookup failed' });
+
+    const hasMxRecords = Array.isArray(verifier.mx_records) ? verifier.mx_records.length > 0 : !!verifier.mx_records;
+    const sourceCount = Array.isArray(verifier.sources) ? verifier.sources.length : (typeof verifier.sources === 'number' ? verifier.sources : null);
+
+    return res.json({
+      ok: true,
+      input: email,
+      result: {
+        status: verifier.status ?? null,
+        result: verifier.result ?? null,
+        score: verifier.score ?? null,
+        regexp: verifier.regexp ?? null,
+        gibberish: verifier.gibberish ?? null,
+        disposable: verifier.disposable ?? null,
+        webmail: verifier.webmail ?? null,
+        mx_records: hasMxRecords,
+        smtp_server: verifier.smtp_server ?? null,
+        smtp_check: verifier.smtp_check ?? null,
+        accept_all: verifier.accept_all ?? null,
+        block: verifier.block ?? null,
+        sources: sourceCount,
+        raw: verifier
+      }
+    });
+  } catch (error) {
+    return res.status(502).json({ error: error.message || 'lookup failed' });
+  }
 });
 
 /** Send a 6-digit OTP to the user's email for password reset */


### PR DESCRIPTION
- Add admin-only Hunter.io-backed email verification endpoint
- Add HUNTER_API_KEY env config
- Replace Lookup placeholder with working Email Verification tool
- Keep API key server-side only
- Handle loading, results, errors, and not-configured states

Validation: server syntax check passed, client build passed