### PR TITLE
Add Numverify phone validation to Lookup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -909,6 +909,11 @@ function LookupPage() {
   const [error, setError] = useState('')
   const [notConfigured, setNotConfigured] = useState(false)
   const [result, setResult] = useState(null)
+  const [phone, setPhone] = useState('')
+  const [phoneLoading, setPhoneLoading] = useState(false)
+  const [phoneError, setPhoneError] = useState('')
+  const [phoneNotConfigured, setPhoneNotConfigured] = useState(false)
+  const [phoneResult, setPhoneResult] = useState(null)
 
   async function verifyEmail(e) {
     e.preventDefault()
@@ -938,6 +943,34 @@ function LookupPage() {
     }
   }
 
+  async function validatePhone(e) {
+    e.preventDefault()
+    setPhoneError('')
+    setPhoneNotConfigured(false)
+    setPhoneResult(null)
+    if (!phone.trim()) {
+      setPhoneError('Phone number is required')
+      return
+    }
+    setPhoneLoading(true)
+    try {
+      const data = await apiFetch('/api/lookup/phone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone })
+      })
+      setPhoneResult(data)
+    } catch (e) {
+      if (e.status === 503) {
+        setPhoneNotConfigured(true)
+        return
+      }
+      setPhoneError(e.message || 'Validation failed')
+    } finally {
+      setPhoneLoading(false)
+    }
+  }
+
   const flags = result?.result ? [
     { label: 'Disposable', value: result.result.disposable },
     { label: 'Webmail', value: result.result.webmail },
@@ -953,6 +986,7 @@ function LookupPage() {
   const isPositiveVerdict = [verdictValue, verdictStatus]
     .filter(Boolean)
     .some(value => positiveVerdicts.includes(String(value).toLowerCase()))
+  const isPhoneValid = !!phoneResult?.result?.valid
 
   return (
     <div className="space-y-6">
@@ -1038,10 +1072,83 @@ function LookupPage() {
               )}
             </div>
           )}
+        </div>
+      </div>
 
-          <div className="rounded-xl border border-dashed border-base-300 bg-base-200/40 px-4 py-6 text-sm text-base-content/60">
-            More lookup tools for phone, name, address, and business research can be added here over time.
+      <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card-body p-5 md:p-6 space-y-5">
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">Phone Validation</h3>
+            <p className="text-sm text-base-content/55">
+              Validate a phone number with Numverify while keeping the API key on the server.
+            </p>
           </div>
+          <form onSubmit={validatePhone} className="space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row">
+              <input
+                type="tel"
+                placeholder="+1 555 123 4567"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+                className="input input-bordered flex-1"
+              />
+              <button className="btn btn-primary md:min-w-32" type="submit" disabled={phoneLoading}>
+                {phoneLoading ? 'Validating…' : 'Validate'}
+              </button>
+            </div>
+          </form>
+
+          {phoneError && (
+            <div className="rounded-xl border border-base-300 bg-base-200/40 px-4 py-3 text-sm text-error">
+              {phoneError}
+            </div>
+          )}
+
+          {phoneNotConfigured && (
+            <div className="rounded-xl border border-dashed border-base-300 bg-base-200/40 px-4 py-4 text-sm text-base-content/60">
+              Numverify is not configured on this server yet.
+            </div>
+          )}
+
+          {phoneResult?.result && (
+            <div className="rounded-xl border border-base-300 bg-base-200/30 p-4 md:p-5 space-y-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-widest text-base-content/50">Validation result</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                    {isPhoneValid && (
+                      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-success/30 bg-success/12 text-sm font-semibold leading-none text-success">
+                        ✓
+                      </span>
+                    )}
+                    <span className={`badge ${isPhoneValid ? 'badge-success' : 'badge-neutral'}`}>{isPhoneValid ? 'valid' : 'invalid'}</span>
+                    {phoneResult.result.line_type && <span className="badge badge-outline">{phoneResult.result.line_type}</span>}
+                  </div>
+                </div>
+                {phoneResult.result.international_format && (
+                  <div className="text-sm text-base-content/70">
+                    <span className="font-semibold text-base-content">{phoneResult.result.international_format}</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {[
+                  { label: 'Country', value: phoneResult.result.country_name || phoneResult.result.country_code || '—' },
+                  { label: 'Location', value: phoneResult.result.location || '—' },
+                  { label: 'Carrier', value: phoneResult.result.carrier || '—' },
+                  { label: 'Line type', value: phoneResult.result.line_type || '—' },
+                  { label: 'International format', value: phoneResult.result.international_format || '—' },
+                  { label: 'Local format', value: phoneResult.result.local_format || '—' }
+                ].map(field => (
+                  <div key={field.label} className="rounded-lg border border-base-300 px-3 py-2 text-sm">
+                    <p className="text-xs uppercase tracking-widest text-base-content/45">{field.label}</p>
+                    <p className="mt-1 font-medium text-base-content">{field.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,4 @@ SESSION_SECRET=change-me-to-a-secure-random-string
 DB_PATH=./users.db
 PORT=3000
 HUNTER_API_KEY= # Hunter.io email verification API key
+NUMVERIFY_API_KEY= # Numverify phone validation API key

--- a/server/index.js
+++ b/server/index.js
@@ -449,6 +449,21 @@ function extractUpstreamError(data, fallback = 'lookup failed') {
     || fallback;
 }
 
+function sanitizePhone(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isPlausiblePhone(value) {
+  if (!value) return false;
+  if (value.length < 7 || value.length > 32) return false;
+  const digits = value.replace(/\D/g, '');
+  return digits.length >= 7 && digits.length <= 15 && /^[\d\s+().-]+$/.test(value);
+}
+
+function isNumverifyProviderError(data) {
+  return data?.success === false || !!data?.error;
+}
+
 /** Verify a reCAPTCHA Enterprise token. Returns { ok, score, reason } */
 async function verifyRecaptcha(token, action) {
   if (!RECAPTCHA_API_KEY) return { ok: true, score: 1, reason: 'no_api_key_configured' };
@@ -635,6 +650,47 @@ app.post('/api/lookup/email', async (req, res) => {
     });
   } catch (error) {
     return res.status(502).json({ error: error.message || 'lookup failed' });
+  }
+});
+
+app.post('/api/lookup/phone', async (req, res) => {
+  if (!req.session.user || req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  const phone = sanitizePhone(req.body?.phone);
+  if (!phone) return res.status(400).json({ error: 'phone required' });
+  if (!isPlausiblePhone(phone)) return res.status(400).json({ error: 'valid phone required' });
+
+  const numverifyApiKey = process.env.NUMVERIFY_API_KEY;
+  if (!numverifyApiKey) {
+    return res.status(503).json({ error: 'lookup service not configured', code: 'LOOKUP_NOT_CONFIGURED' });
+  }
+
+  try {
+    const url = `https://apilayer.net/api/validate?access_key=${encodeURIComponent(numverifyApiKey)}&number=${encodeURIComponent(phone)}`;
+    const upstream = await getJson(url);
+
+    if (!upstream.ok || isNumverifyProviderError(upstream.data)) {
+      return res.status(502).json({ error: 'phone lookup provider error' });
+    }
+
+    const validation = upstream.data;
+    return res.json({
+      ok: true,
+      input: phone,
+      result: {
+        valid: validation.valid ?? false,
+        international_format: validation.international_format ?? null,
+        local_format: validation.local_format ?? null,
+        country_prefix: validation.country_prefix ?? null,
+        country_code: validation.country_code ?? null,
+        country_name: validation.country_name ?? null,
+        location: validation.location ?? null,
+        carrier: validation.carrier ?? null,
+        line_type: validation.line_type ?? null,
+        raw: validation
+      }
+    });
+  } catch (error) {
+    return res.status(502).json({ error: 'phone lookup provider error' });
   }
 });
 


### PR DESCRIPTION
- Add admin-only Numverify-backed phone validation endpoint
- Add NUMVERIFY_API_KEY env config
- Add Phone Validation tool to Lookup
- Keep API key server-side only
- Include loading, result, error, and not-configured states

Validation: server syntax check passed, client build passed