### PR TITLE
Track Hunter and Numverify usage internally

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -914,6 +914,25 @@ function LookupPage() {
   const [phoneError, setPhoneError] = useState('')
   const [phoneNotConfigured, setPhoneNotConfigured] = useState(false)
   const [phoneResult, setPhoneResult] = useState(null)
+  const [usage, setUsage] = useState(null)
+
+  const formatCredits = useCallback((value) => {
+    const numeric = Number(value || 0)
+    return Number.isInteger(numeric) ? String(numeric) : numeric.toFixed(1)
+  }, [])
+
+  const loadUsage = useCallback(async () => {
+    try {
+      const data = await apiFetch('/api/lookup/usage')
+      setUsage(data)
+    } catch (e) {
+      if (e.status !== 403) console.error('Failed to load usage:', e.message)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadUsage()
+  }, [loadUsage])
 
   async function verifyEmail(e) {
     e.preventDefault()
@@ -932,6 +951,7 @@ function LookupPage() {
         body: JSON.stringify({ email })
       })
       setResult(data)
+      await loadUsage()
     } catch (e) {
       if (e.status === 503) {
         setNotConfigured(true)
@@ -960,6 +980,7 @@ function LookupPage() {
         body: JSON.stringify({ phone })
       })
       setPhoneResult(data)
+      await loadUsage()
     } catch (e) {
       if (e.status === 503) {
         setPhoneNotConfigured(true)
@@ -987,6 +1008,10 @@ function LookupPage() {
     .filter(Boolean)
     .some(value => positiveVerdicts.includes(String(value).toLowerCase()))
   const isPhoneValid = !!phoneResult?.result?.valid
+  const usageCards = [
+    { key: 'hunter', label: 'Hunter.io' },
+    { key: 'numverify', label: 'Numverify' }
+  ]
 
   return (
     <div className="space-y-6">
@@ -995,6 +1020,31 @@ function LookupPage() {
         <p className="text-sm text-base-content/60 max-w-3xl">
           This admin area will host phone, email, name, address, and business lookup tools.
         </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {usageCards.map(card => {
+          const providerUsage = usage?.[card.key]
+          return (
+            <div key={card.key} className="rounded-xl border border-base-300 bg-base-100 px-4 py-3 shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold">{card.label}</p>
+                  <p className="text-xs text-base-content/55">
+                    {providerUsage
+                      ? `${formatCredits(providerUsage.remaining)} remaining / ${formatCredits(providerUsage.limit)} total`
+                      : 'Loading usage…'}
+                  </p>
+                </div>
+                {providerUsage && (
+                  <span className="text-xs text-base-content/45">
+                    {formatCredits(providerUsage.costPerRequest)} credit / request
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })}
       </div>
 
       <div className="card bg-base-100 border border-base-300 shadow-sm">

--- a/server/index.js
+++ b/server/index.js
@@ -256,6 +256,21 @@ async function initializeSchema() {
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   )`);
 
+  await pool.query(`CREATE TABLE IF NOT EXISTS provider_usage (
+    provider TEXT PRIMARY KEY,
+    used_credits NUMERIC NOT NULL DEFAULT 0,
+    credit_limit NUMERIC NOT NULL DEFAULT 0,
+    credit_cost_per_request NUMERIC NOT NULL DEFAULT 1,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`);
+  await pool.query(`
+    INSERT INTO provider_usage (provider, used_credits, credit_limit, credit_cost_per_request)
+    VALUES
+      ('hunter', 0.5, 50, 0.5),
+      ('numverify', 3, 100, 1)
+    ON CONFLICT (provider) DO NOTHING
+  `);
+
   // Drop and recreate session table with correct schema for connect-pg-simple v8
   await pool.query(`DROP TABLE IF EXISTS "session"`);
   await pool.query(`CREATE TABLE "session" (
@@ -449,6 +464,49 @@ function extractUpstreamError(data, fallback = 'lookup failed') {
     || fallback;
 }
 
+async function getProviderUsage(provider) {
+  const result = await pool.query(
+    `SELECT provider, used_credits, credit_limit, credit_cost_per_request, updated_at
+     FROM provider_usage
+     WHERE provider = $1`,
+    [provider]
+  );
+  return result.rows[0] || null;
+}
+
+async function listProviderUsage() {
+  const result = await pool.query(
+    `SELECT provider, used_credits, credit_limit, credit_cost_per_request, updated_at
+     FROM provider_usage
+     ORDER BY provider ASC`
+  );
+  return result.rows;
+}
+
+async function incrementProviderUsage(provider) {
+  const result = await pool.query(
+    `UPDATE provider_usage
+     SET used_credits = used_credits + credit_cost_per_request,
+         updated_at = CURRENT_TIMESTAMP
+     WHERE provider = $1
+     RETURNING provider, used_credits, credit_limit, credit_cost_per_request, updated_at`,
+    [provider]
+  );
+  return result.rows[0] || null;
+}
+
+function serializeProviderUsageRow(row) {
+  const used = Number(row.used_credits || 0);
+  const limit = Number(row.credit_limit || 0);
+  const costPerRequest = Number(row.credit_cost_per_request || 0);
+  return {
+    used,
+    limit,
+    remaining: Math.max(limit - used, 0),
+    costPerRequest
+  };
+}
+
 function sanitizePhone(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -624,6 +682,8 @@ app.post('/api/lookup/email', async (req, res) => {
     const hasMxRecords = Array.isArray(verifier.mx_records) ? verifier.mx_records.length > 0 : !!verifier.mx_records;
     const sourceCount = Array.isArray(verifier.sources) ? verifier.sources.length : (typeof verifier.sources === 'number' ? verifier.sources : null);
 
+    await incrementProviderUsage('hunter');
+
     return res.json({
       ok: true,
       input: email,
@@ -673,6 +733,7 @@ app.post('/api/lookup/phone', async (req, res) => {
     }
 
     const validation = upstream.data;
+    await incrementProviderUsage('numverify');
     return res.json({
       ok: true,
       input: phone,
@@ -687,6 +748,23 @@ app.post('/api/lookup/phone', async (req, res) => {
         carrier: validation.carrier ?? null,
         line_type: validation.line_type ?? null,
         raw: validation
+      }
+    });
+
+    app.get('/api/lookup/usage', async (req, res) => {
+      if (!req.session.user || req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+      try {
+        const rows = await listProviderUsage();
+        const usage = rows.reduce((acc, row) => {
+          acc[row.provider] = serializeProviderUsageRow(row);
+          return acc;
+        }, {});
+        return res.json({
+          hunter: usage.hunter || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 },
+          numverify: usage.numverify || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 }
+        });
+      } catch (error) {
+        return res.status(500).json({ error: 'failed to load provider usage' });
       }
     });
   } catch (error) {


### PR DESCRIPTION
- Add shared persisted provider usage tracking
- Seed Hunter usage at 0.5/50 and Numverify at 3/100
- Increment usage only on successful requests
- Add /api/lookup/usage and show remaining credits in Lookup
- Refresh usage after successful validations

Validation: server syntax check passed, client build passed