### PR TITLE
Fix lookup usage loading

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -915,6 +915,8 @@ function LookupPage() {
   const [phoneNotConfigured, setPhoneNotConfigured] = useState(false)
   const [phoneResult, setPhoneResult] = useState(null)
   const [usage, setUsage] = useState(null)
+  const [usageLoading, setUsageLoading] = useState(true)
+  const [usageError, setUsageError] = useState('')
 
   const formatCredits = useCallback((value) => {
     const numeric = Number(value || 0)
@@ -922,11 +924,21 @@ function LookupPage() {
   }, [])
 
   const loadUsage = useCallback(async () => {
+    setUsageLoading(true)
+    setUsageError('')
     try {
       const data = await apiFetch('/api/lookup/usage')
       setUsage(data)
     } catch (e) {
-      if (e.status !== 403) console.error('Failed to load usage:', e.message)
+      setUsage(null)
+      if (e.status === 403) {
+        setUsageError('Usage is only available to admins')
+      } else {
+        setUsageError(e.message || 'Failed to load usage')
+        console.error('Failed to load usage:', e.message)
+      }
+    } finally {
+      setUsageLoading(false)
     }
   }, [])
 
@@ -1013,6 +1025,11 @@ function LookupPage() {
     { key: 'numverify', label: 'Numverify' }
   ]
 
+  const getUsagePercent = (providerUsage) => {
+    if (!providerUsage?.limit) return 0
+    return Math.min((providerUsage.used / providerUsage.limit) * 100, 100)
+  }
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -1025,6 +1042,7 @@ function LookupPage() {
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         {usageCards.map(card => {
           const providerUsage = usage?.[card.key]
+          const usagePercent = getUsagePercent(providerUsage)
           return (
             <div key={card.key} className="rounded-xl border border-base-300 bg-base-100 px-4 py-3 shadow-sm">
               <div className="flex items-start justify-between gap-3">
@@ -1033,13 +1051,27 @@ function LookupPage() {
                   <p className="text-xs text-base-content/55">
                     {providerUsage
                       ? `${formatCredits(providerUsage.remaining)} remaining / ${formatCredits(providerUsage.limit)} total`
-                      : 'Loading usage…'}
+                      : usageError || (usageLoading ? 'Loading usage…' : 'Usage unavailable')}
                   </p>
                 </div>
                 {providerUsage && (
                   <span className="text-xs text-base-content/45">
                     {formatCredits(providerUsage.costPerRequest)} credit / request
                   </span>
+                )}
+              </div>
+              <div className="mt-3 space-y-2">
+                <div className="h-2 overflow-hidden rounded-full bg-base-200">
+                  <div
+                    className="h-full rounded-full bg-primary transition-all"
+                    style={{ width: `${usagePercent}%` }}
+                  />
+                </div>
+                {providerUsage && (
+                  <div className="flex items-center justify-between text-xs text-base-content/55">
+                    <span>{formatCredits(providerUsage.used)} used</span>
+                    <span>{Math.round(usagePercent)}%</span>
+                  </div>
                 )}
               </div>
             </div>

--- a/server/index.js
+++ b/server/index.js
@@ -751,24 +751,25 @@ app.post('/api/lookup/phone', async (req, res) => {
       }
     });
 
-    app.get('/api/lookup/usage', async (req, res) => {
-      if (!req.session.user || req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
-      try {
-        const rows = await listProviderUsage();
-        const usage = rows.reduce((acc, row) => {
-          acc[row.provider] = serializeProviderUsageRow(row);
-          return acc;
-        }, {});
-        return res.json({
-          hunter: usage.hunter || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 },
-          numverify: usage.numverify || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 }
-        });
-      } catch (error) {
-        return res.status(500).json({ error: 'failed to load provider usage' });
-      }
-    });
   } catch (error) {
     return res.status(502).json({ error: 'phone lookup provider error' });
+  }
+});
+
+app.get('/api/lookup/usage', async (req, res) => {
+  if (!req.session.user || req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  try {
+    const rows = await listProviderUsage();
+    const usage = rows.reduce((acc, row) => {
+      acc[row.provider] = serializeProviderUsageRow(row);
+      return acc;
+    }, {});
+    return res.json({
+      hunter: usage.hunter || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 },
+      numverify: usage.numverify || { used: 0, limit: 0, remaining: 0, costPerRequest: 0 }
+    });
+  } catch (error) {
+    return res.status(500).json({ error: 'failed to load provider usage' });
   }
 });
 


### PR DESCRIPTION
## Summary
- move the lookup usage route out of the phone validation handler so it responds correctly
- add usage progress bars under the remaining-credit counts
- surface usage fetch errors instead of leaving the cards stuck on loading

## Testing
- npm run build (client)
