### PR TITLE
Fix provider usage seed placeholders

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -301,11 +301,20 @@ async function initializeSchema() {
   await pool.query(`
     INSERT INTO provider_usage (provider, used_credits, credit_limit, credit_cost_per_request, reset_period, reset_anchor, last_reset_at)
     VALUES
-      ('hunter', 0.5, 50, 0.5),
-      ('numverify', 3, 100, 1),
-      ('google-ai-studio-search', 0, 1000, 1)
-    ON CONFLICT (provider) DO NOTHING
-  `);
+      ('hunter', 0, 50, 0.5, 'monthly', $1, $1),
+      ('numverify', 0, 100, 1, 'monthly', $2, $2),
+      ('google-ai-studio-search', 0, 250, 1, 'daily', $3, $3)
+    ON CONFLICT (provider) DO UPDATE SET
+      credit_limit = EXCLUDED.credit_limit,
+      credit_cost_per_request = EXCLUDED.credit_cost_per_request,
+      reset_period = EXCLUDED.reset_period,
+      reset_anchor = COALESCE(provider_usage.reset_anchor, EXCLUDED.reset_anchor),
+      last_reset_at = COALESCE(provider_usage.last_reset_at, EXCLUDED.last_reset_at)
+  `, [
+    PROVIDER_USAGE_RESET_START.toISOString(),
+    PROVIDER_USAGE_RESET_START.toISOString(),
+    PROVIDER_USAGE_RESET_START.toISOString()
+  ]);
 
   // Drop and recreate session table with correct schema for connect-pg-simple v8
   await pool.query(`DROP TABLE IF EXISTS "session"`);


### PR DESCRIPTION
## Summary
- cherry-pick the provider_usage seed placeholder fix onto a clean branch from master
- seed provider_usage rows with reset period and timestamp placeholders so Render startup no longer fails on insert

## Validation
- node --check server\\index.js
- Set-Location client; npm run build