### PR TITLE
Fix market layout and contact detail crash

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1074,7 +1074,7 @@ function MarketsPage() {
         </p>
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[360px,minmax(0,1fr)]">
+      <div className="grid gap-6 lg:grid-cols-[360px,minmax(0,1fr)] lg:items-start">
         <div className="space-y-4">
           <div className="card bg-base-100 border border-base-300 shadow-sm">
             <div className="card-body p-5 md:p-6 space-y-4">

--- a/client/src/ContactsPage.jsx
+++ b/client/src/ContactsPage.jsx
@@ -537,17 +537,6 @@ export default function ContactsPage() {
   // Debounce search input
   const debouncedSearch = useDebounce(search, 200)
 
-  // If a contact detail is open, render full-page view instead
-  if (detailId) {
-    return (
-      <ContactDetailPage
-        contactId={detailId}
-        onBack={closeDetail}
-        isAdmin
-      />
-    )
-  }
-
   const adminContacts = contacts.filter(c => c.role === 'admin')
   const userContacts = contacts.filter(c => c.role === 'user')
   const otherContacts = contacts.filter(c => c.role !== 'admin' && c.role !== 'user')
@@ -599,6 +588,17 @@ export default function ContactsPage() {
     })
     return sorted
   }, [roleFilteredContacts, listSort])
+
+  // If a contact detail is open, render full-page view instead
+  if (detailId) {
+    return (
+      <ContactDetailPage
+        contactId={detailId}
+        onBack={closeDetail}
+        isAdmin
+      />
+    )
+  }
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- move the Markets page to the same left-content/right-visual layout used by the property module
- fix the contact double-click crash by keeping hook order stable before rendering the full detail view