### PR TITLE
Fix dashboard treasury symbol

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2200,10 +2200,10 @@ export default function App() {
                 <div className="space-y-1">
                   <h2 className="text-lg font-semibold">10 Year US Treasury</h2>
                   <p className="text-sm text-base-content/55">
-                    Live TradingView chart for the benchmark US10Y yield.
+                    Live TradingView chart for the benchmark 10-year Treasury yield.
                   </p>
                 </div>
-                <TradingViewEmbed symbol="TVC:US10Y" />
+                <TradingViewEmbed symbol="CBOE:TNX" />
               </div>
             </div>
           </div>

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ const MARKET_SYMBOL_SUGGESTIONS = [
   { symbol: 'EURUSD', exchange: 'FX', display_name: 'Euro / U.S. Dollar', type: 'forex' },
   { symbol: 'GBPUSD', exchange: 'FX', display_name: 'British Pound / U.S. Dollar', type: 'forex' },
   { symbol: 'USDJPY', exchange: 'FX', display_name: 'U.S. Dollar / Japanese Yen', type: 'forex' },
-  { symbol: 'US10Y', exchange: 'TVC', display_name: 'U.S. 10 Year Treasury Yield', type: 'bond' }
+  { symbol: 'TNX', exchange: 'CBOE', display_name: 'U.S. 10 Year Treasury Yield', type: 'bond' }
 ];
 
 const resend = new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
## Summary
- replace the non-embeddable dashboard Treasury symbol with an embeddable TradingView symbol
- update the matching market suggestion so saved symbols and suggestions use the same working symbol