### PR TITLE
Use TVC treasury symbol

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2203,7 +2203,7 @@ export default function App() {
                     Live TradingView chart for the benchmark 10-year Treasury yield.
                   </p>
                 </div>
-                <TradingViewEmbed symbol="CBOE:TNX" />
+                <TradingViewEmbed symbol="TVC:TNX" />
               </div>
             </div>
           </div>

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ const MARKET_SYMBOL_SUGGESTIONS = [
   { symbol: 'EURUSD', exchange: 'FX', display_name: 'Euro / U.S. Dollar', type: 'forex' },
   { symbol: 'GBPUSD', exchange: 'FX', display_name: 'British Pound / U.S. Dollar', type: 'forex' },
   { symbol: 'USDJPY', exchange: 'FX', display_name: 'U.S. Dollar / Japanese Yen', type: 'forex' },
-  { symbol: 'TNX', exchange: 'CBOE', display_name: 'U.S. 10 Year Treasury Yield', type: 'bond' }
+  { symbol: 'TNX', exchange: 'TVC', display_name: 'U.S. 10 Year Treasury Yield', type: 'bond' }
 ];
 
 const resend = new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
## Summary
- switch the dashboard Treasury chart to TradingView's public TVC treasury-yield symbol
- align the matching market suggestion with the same TVC symbol