### PR TITLE
Use treasury futures symbol

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2200,10 +2200,10 @@ export default function App() {
                 <div className="space-y-1">
                   <h2 className="text-lg font-semibold">10 Year US Treasury</h2>
                   <p className="text-sm text-base-content/55">
-                    Live TradingView chart for the benchmark 10-year Treasury yield.
+                    Live TradingView chart for the front-month 10-year Treasury futures contract.
                   </p>
                 </div>
-                <TradingViewEmbed symbol="TVC:TNX" />
+                <TradingViewEmbed symbol="CBOT:ZN1!" />
               </div>
             </div>
           </div>

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ const MARKET_SYMBOL_SUGGESTIONS = [
   { symbol: 'EURUSD', exchange: 'FX', display_name: 'Euro / U.S. Dollar', type: 'forex' },
   { symbol: 'GBPUSD', exchange: 'FX', display_name: 'British Pound / U.S. Dollar', type: 'forex' },
   { symbol: 'USDJPY', exchange: 'FX', display_name: 'U.S. Dollar / Japanese Yen', type: 'forex' },
-  { symbol: 'TNX', exchange: 'TVC', display_name: 'U.S. 10 Year Treasury Yield', type: 'bond' }
+  { symbol: 'ZN1!', exchange: 'CBOT', display_name: 'U.S. 10 Year Treasury Note Futures', type: 'bond' }
 ];
 
 const resend = new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
## Summary
- replace the unsupported dashboard Treasury-yield symbol with a public 10-year Treasury futures symbol
- align the matching market suggestion with the same CBOT futures contract